### PR TITLE
Fixing Diamond CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -177,7 +177,7 @@
         </div>
     </div>
     <hr class="bruh"><br />
-    <div class="container resize d-flex justify-content-center">
+    <div class="container d-flex justify-content-center">
         <div class="d-container">
             <div class="row top-row">
                 <div class="col-lg">


### PR DESCRIPTION
Removed resize class from diamond because it caused resizing issues with small window size or mobile.