### PR TITLE
Small Fixes

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,15 +1,15 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<title>NovaCrypt | About</title>
+	<title>About | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
 	<!-- Fonts -->
 	<link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">
-	<!-- Icons -->
-	<link href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" rel="stylesheet">
 
         <!-- Icons -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/css/all.min.css" rel="stylesheet">

--- a/about_team.html
+++ b/about_team.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | About Team</title>
+    <title>About Team | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/announcements.html
+++ b/announcements.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Announcements</title>
+    <title>Announcements | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/articles.html
+++ b/articles.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Articles</title>
+    <title>Articles | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/auraedge.html
+++ b/auraedge.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <title>NovaCrypt | AuraEdge</title>
+  <title>AuraEdge | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/blog.html
+++ b/blog.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Blog</title>
+    <title>Blog | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/contact.html
+++ b/contact.html
@@ -1,9 +1,13 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
+
+    <title>Contact Us | NovaCrypt</title>
+
+    <meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>NovaCrypt | Contact Us</title>
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
+
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">
 

--- a/covid-19.html
+++ b/covid-19.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <title>NovaCrypt | COVID-19</title>
+    <title>COVID-19 | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,10 +1,12 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Dashboard</title>
+    <title>Dashboard | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Home</title>
+    <title>NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/interinit.html
+++ b/interinit.html
@@ -2,10 +2,12 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | The Interstellar Initiative</title>
+    <title>The Interstellar Initiative | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/login.html
+++ b/login.html
@@ -4,7 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>NovaCrypt | Login</title>
+    <title>Login | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/mediair.html
+++ b/mediair.html
@@ -1,10 +1,12 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<title>NovaCrypt | MediAir</title>
+	<title>MediAir | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
 	<!-- Fonts -->
 	<link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/papers.html
+++ b/papers.html
@@ -1,10 +1,12 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<title>NovaCrypt | Research + Projects</title>
+	<title>Research + Projects | NovaCrypt</title>
+
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
 	<!-- Fonts -->
 	<link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/support.html
+++ b/support.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
-
     <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-        <title>NovaCrypt | The Interstellar Initiative</title>
+        <title>The Interstellar Initiative | NovaCrypt</title>
+
+        <meta charset="utf-8">
+    	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">

--- a/team_members.html
+++ b/team_members.html
@@ -2,10 +2,11 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Team Members | NovaCrypt</title>
 
-    <title>NovaCrypt | Team Members</title>
+    <meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="shortcut icon" href="https://novacrypt.org/assets/images/novacrypt.png">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@700&display=swap" rel="stylesheet">


### PR DESCRIPTION
- Updated font awesome
- `<br>`-tag & `<img>`-tag shouldn't have `/>` ending because in html5 they're unnecessary
- Removed nucleo-icons (due to 404)
- Fixed social icons in MediAir page (removed Google Plus)
- Removed missing js tags
- Adding icon also moved meta and link tags below title 